### PR TITLE
[new release] zanuda (2.0.0)

### DIFF
--- a/packages/zanuda/zanuda.2.0.0/opam
+++ b/packages/zanuda/zanuda.2.0.0/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Linter for OCaml+dune projects"
+description:
+  "Lints for OCaml projects. Primary usage is for teaching/education"
+maintainer: ["kakadu@pm.me"]
+authors: ["Kakadu"]
+license: "LGPL-3.0-only"
+tags: ["lint" "test"]
+homepage: "https://github.com/Kakadu/zanuda"
+bug-reports: "https://github.com/Kakadu/zanuda/issues"
+depends: [
+  "dune" {>= "3.4"}
+  "ocaml" {= "4.14.2" | >= "5.3.0" & < "5.4.0"}
+  "yojson" {>= "2.0.0"}
+  "angstrom" {>= "0.15.0" & <= "0.16.0"}
+  "sexplib"
+  "bisect_ppx"
+  "dune-build-info"
+  "ppx_assert"
+  "ppx_expect_nobase"
+  "ppx_optcomp"
+  "base" {with-test}
+  "ppx_assert" {with-test}
+  "ppx_inline_test" {with-test}
+  "ppx_expect" {with-test}
+  "ppx_fields_conv" {with-test}
+  "ppx_deriving" {with-test}
+  "ppx_blob" {with-test}
+  "menhir" {with-test}
+  "ocamlformat" {= "0.27.0" & with-dev-setup}
+  "odoc" {with-doc}
+  "odig" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/Kakadu/zanuda.git"
+url {
+  src:
+    "https://github.com/Kakadu/zanuda/releases/download/v2.0.0/zanuda-2.0.0.tbz"
+  checksum: [
+    "sha256=1da7bb7d5d71ab51fecc381a62c8923bbb4795d63d971b48a21d0430c866e41d"
+    "sha512=1a6901d8f6f706d328e78404973c76985a01321147566280d530336e73d99b348f1f6e7fef9f3fb5c4544d774c4ec1e823bfca41f6e2538ad457042ad7f36535"
+  ]
+}
+x-commit-hash: "59edd94d96cf6cdc3ec98316e78afc773bb811ee"


### PR DESCRIPTION
Linter for OCaml+dune projects

- Project page: <a href="https://github.com/Kakadu/zanuda">https://github.com/Kakadu/zanuda</a>

##### CHANGES:

* OCaml 5.3 support


